### PR TITLE
Incremented bower dependency version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Alternatively, this can be done by defining a `package.json`:
 ```json
 {
     "dependencies": {
-        "bower":">=1.2.8"
+        "bower":">=1.3.8"
     }
 }
 ```


### PR DESCRIPTION
A recent update in Node.js broke some APIs, so it is required to update the version of Bower used. Details at https://github.com/bower/bower/pull/1403
