### PR TITLE
Add dependency for test-unit

### DIFF
--- a/web_blocks.gemspec
+++ b/web_blocks.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'test-unit'
 
 end


### PR DESCRIPTION
This isn't included in Ruby stdlib for all versions, so we should include it explicitly.