### PR TITLE
Fix #28 - Add new external_component_block def that maps to bower_components

### DIFF
--- a/lib/web_blocks/facade/external_component_block.rb
+++ b/lib/web_blocks/facade/external_component_block.rb
@@ -1,0 +1,19 @@
+require 'web_blocks/structure/block'
+
+module WebBlocks
+  module Facade
+    module ExternalComponentBlock
+
+      def external_component_block name, attributes = {}, &block
+        if attributes.has_key?(:path)
+          attributes[:path] = "bower_components/#{name}/#{attributes[:path]}"
+        else
+          attributes[:path] = "bower_components/#{name}"
+        end
+        self.block name, attributes, &block
+      end
+
+    end
+  end
+end
+

--- a/lib/web_blocks/structure/framework.rb
+++ b/lib/web_blocks/structure/framework.rb
@@ -1,3 +1,4 @@
+require 'web_blocks/facade/external_component_block'
 require 'web_blocks/structure/block'
 require 'web_blocks/structure/raw_file'
 require 'web_blocks/support/tsort/hash'
@@ -5,6 +6,8 @@ require 'web_blocks/support/tsort/hash'
 module WebBlocks
   module Structure
     class Framework < Block
+
+      include WebBlocks::Facade::ExternalComponentBlock
 
       set :required, true
 


### PR DESCRIPTION
This pull request adds a new `external_component_block` definition that you can use when you're building wrappers so that, instead of writing this:

```ruby
block 'jquery', :path => 'bower_components/jquery/dist' do
  js_file 'jquery.js'
end
```

You write this:

```ruby
external_component_block 'jquery', :path => 'dist' do
  js_file 'jquery.js'
end
```

It's not really shorter, but it's technology-agnostic (in case we leave bower someday) and more clear as to the special-ness of the type of block we're defining.