### PR TITLE
Add recursive_file_names_block macro

### DIFF
--- a/lib/web_blocks/facade/file_name_block.rb
+++ b/lib/web_blocks/facade/file_name_block.rb
@@ -27,6 +27,7 @@ module WebBlocks
           end
           block_entity.instance_eval &block if block_was_given
         end
+
       end
 
     end

--- a/lib/web_blocks/facade/recursive_file_names_block.rb
+++ b/lib/web_blocks/facade/recursive_file_names_block.rb
@@ -1,0 +1,47 @@
+require 'set'
+require 'web_blocks/facade/base'
+require 'web_blocks/facade/file_name_block'
+
+module WebBlocks
+  module Facade
+    class RecursiveFileNamesBlock < Base
+
+      def handle name, attributes = {}, &block
+
+        this = self
+
+        attributes[:path] = name unless attributes.has_key? :path
+
+        block_was_given = block_given?
+
+        this.context.block name, attributes do |directory_block|
+
+          directory_path = directory_block.resolved_path
+          directory_facade = ::WebBlocks::Facade::RecursiveFileNamesBlock.new(directory_block)
+          file_facade = ::WebBlocks::Facade::FileNameBlock.new(directory_block)
+          file_names = Set.new
+
+          Dir.entries(directory_path).each do |name|
+            next if name == '.' or name == '..'
+            path = "#{directory_path}/#{name}"
+            if File.directory? path
+              directory_facade.handle name, path: name
+            else
+              segs = name.split('.')
+              ext = segs.pop
+              if file_facade.types.keys.include? ext
+                file_names << segs.join('.')
+              end
+            end
+          end
+
+          file_names.each { |name| file_facade.handle name }
+
+          directory_block.instance_eval &block if block_was_given
+
+        end
+      end
+
+    end
+  end
+end

--- a/lib/web_blocks/structure/block_core.rb
+++ b/lib/web_blocks/structure/block_core.rb
@@ -46,6 +46,17 @@ module WebBlocks
         end
       end
 
+      def isolated_facade_registration_scope &block
+        facade_map = @facade_map
+        begin
+          instance_eval &block
+          @facade_map = facade_map
+        rescue => e
+          @facade_map = facade_map
+          raise e
+        end
+      end
+
       def method_missing name, *arguments, &block
         handler_class = resolve_facade(name)
         handler_class = resolve_class_facade(name) unless handler_class

--- a/lib/web_blocks/structure/framework.rb
+++ b/lib/web_blocks/structure/framework.rb
@@ -17,10 +17,12 @@ module WebBlocks
         resolved_block_path = resolved_path + path
         blockfile_path =  resolved_block_path + "Blockfile.rb"
         raise "Undefined blockfile for #{path}" unless File.exists?(blockfile_path)
-        block name do
-          set :base_path, resolved_block_path
+        isolated_facade_registration_scope do
+          block name do
+            set :base_path, resolved_block_path
+          end
+          instance_eval File.read(blockfile_path)
         end
-        instance_eval File.read(blockfile_path)
       end
 
       def include *args


### PR DESCRIPTION
Originally, we had definitions like:

```ruby
block 'efx', :path => 'src' do |efx|

  block 'engine', :required => true do
    loose_dependency framework.route 'jquery'
    js_file 'engine.js'
  end

  block 'driver', :path => 'driver' do

    dependency efx.route 'engine'

    block 'accordion' do
      scss_file 'accordion.css'
      js_file 'accordion.js'
    end

    block 'tabs' do
      scss_file 'tabs.css'
      js_file 'tabs.js'
    end

    block 'toggle' do
      scss_file 'toggle.css'
      js_file 'toggle.js'
    end

  end

end
```

Then #61 made it possible to rewrite this as:

```ruby
require 'web_blocks/facade/file_name_block'

block 'efx', :path => 'src' do |efx|

  register_facade :recursive_file_names_block, ::WebBlocks::Facade::RecursiveFileNamesBlock

  file_name_block 'engine', :required => true do
    loose_dependency framework.route 'jquery'
  end

  block 'driver', :path => 'driver' do

    dependency efx.route 'engine'

    file_name_block 'accordion'
    file_name_block 'tabs'
    file_name_block 'toggle'

  end

end
```

This one takes it a step further and implicitly loads directories as sub-blocks, and then uses `file_name_block` for the actual leaf blocks:

```ruby
require 'web_blocks/facade/recursive_file_names_block'

register_facade :recursive_file_names_block, ::WebBlocks::Facade::RecursiveFileNamesBlock

recursive_file_names_block 'efx', path: 'src' do |efx|

  block 'engine', required: true do
    loose_dependency framework.route 'jquery'
  end

  block 'driver' do
    dependency efx.route 'engine'
  end

end
```

If it weren't for the dependencies, it would be as simple as:

```ruby
require 'web_blocks/facade/recursive_file_names_block'

register_facade :recursive_file_names_block, ::WebBlocks::Facade::RecursiveFileNamesBlock

recursive_file_names_block 'efx', path: 'src'
```

For leakage between multiple blockfiles, registration is protected by:

```ruby
        isolated_facade_registration_scope do
          block name do
            set :base_path, resolved_block_path
          end
          instance_eval File.read(blockfile_path)
        end
```

This makes it essentially:

```ruby
require 'web_blocks/facade/recursive_file_names_block'

isolated_facade_registration_scope do

  register_facade :recursive_file_names_block, ::WebBlocks::Facade::RecursiveFileNamesBlock

  recursive_file_names_block 'efx', path: 'src' do |efx|

    block 'engine', required: true do
      loose_dependency framework.route 'jquery'
    end

    block 'driver' do
      dependency efx.route 'engine'
    end

  end

end
```

This is important in cases when a blockfile leverages a facade at the base level, as opposed to within some subscope. This wrapper is available to the end user to prevent leakage when doing their own fancy stuff as well.