### PR TITLE
Add new before/after primitives and event notifier system plus metadata

### DIFF
--- a/lib/web_blocks/facade/registration_scope.rb
+++ b/lib/web_blocks/facade/registration_scope.rb
@@ -6,17 +6,17 @@ module WebBlocks
 
       def initialize context
         super context
-        @@component = nil unless defined? @@component
+        @@registration_scope = nil unless defined? @@registration_scope
       end
 
       def handle command = nil, data = {}, &block
         case command
           when :set
-            @@component = data
+            @@registration_scope = data
           when :unset
-            @@component = nil
+            @@registration_scope = nil
         end
-        @@component
+        @@registration_scope
       end
 
     end

--- a/lib/web_blocks/facade/registration_scope.rb
+++ b/lib/web_blocks/facade/registration_scope.rb
@@ -1,0 +1,25 @@
+require 'web_blocks/facade/base'
+
+module WebBlocks
+  module Facade
+    class RegistrationScope < Base
+
+      def initialize context
+        super context
+        @@component = nil unless defined? @@component
+      end
+
+      def handle command = nil, data = {}, &block
+        case command
+          when :set
+            @@component = data
+          when :unset
+            @@component = nil
+        end
+        @@component
+      end
+
+    end
+  end
+end
+

--- a/lib/web_blocks/thor/base/prepare_blocks.rb
+++ b/lib/web_blocks/thor/base/prepare_blocks.rb
@@ -27,6 +27,11 @@ module WebBlocks
                    :default => nil,
                    :desc => 'Path where WebBlocks should build products'
 
+      class_option :env,
+                   :type => :string,
+                   :default => nil,
+                   :desc => 'Name of the environment'
+
       no_commands do
 
         def prepare_blocks!
@@ -62,7 +67,23 @@ module WebBlocks
             include_routes_from_command_line! log if self.options.include
             set_build_path_from_command_line!
 
+            framework.notify :after_prepare_blocks, runner: self, log: log
+
           end
+
+        end
+
+        def reload_blocks! log
+
+          ::WebBlocks::Framework.class_variable_set(:@@framework, ::WebBlocks::Structure::Framework.new('framework'))
+
+          initialize_root!
+
+          load_bower_registry! log
+          load_blockfile! log
+          include_own_routes! log
+          include_routes_from_command_line! log if self.options.include
+          set_build_path_from_command_line!
 
         end
 


### PR DESCRIPTION
This pull request adds several features:
1. A new `registration_scope` object that can be checked within a Blockfile to determine if the Blockfile is being registered as a component or if it's the root Blockfile.
2. A new notification system whereby an event may be dispatched as `framework.notify event_name, data` and blocks that listen for the dispatch can be attached via `framework.for_notification event_name, &block`, where `&block` optionally receives the  `data` component passed to `framework.notify`.
3. New DSL methods `after event_name, &block` and `before event_name, &block` that forward to `framework.notify` after appending `before_` or `after_` to the event name. These are friendly helpers for the actual events we will add to the runtime.
4. An event `after_prepare_blocks` that is fired by the command-line runner after it has reloaded bower components, loaded the blocks, etc.
5. A new `--env [environment-name]` argument that you can send to any `blocks` command that will be available as an option on the runner.

Here's an example, taken from a CloudCompli Blockfile, that shows how this is used. Essentially, what it says is that, if Blockfile is being used as the actual base Blockfile (and not as a component for another build), then after blocks are prepared, if the environment is dev, run an external command and then reload the blocks:

``` ruby
require 'systemu'

unless registration_scope

  after 'prepare_blocks' do |context|

    if context[:runner].options[:env] == 'dev'

      status, stdout, stderr = systemu 'php artisan local:bower:link'
      stdout.split(/\r?\n/).each { |out_line| puts "[ARTISAN] #{out_line}" }

      context[:runner].reload_blocks! context[:log]

    end

  end

end
```
